### PR TITLE
dockerized-annotation-ui-and-shared-network-setup

### DIFF
--- a/playbooks/deploy_server.yml
+++ b/playbooks/deploy_server.yml
@@ -1,13 +1,6 @@
 # Local_Deployment
-## deploy_UI.yml
-- name: Deploy UI Service
-  hosts: UI_Local
-  tags: UI_Local
-  become: true
-  roles:
-    - UI
 
-## deploy_custom_atomspace.yml
+# deploy_custom_atomspace
 - name: Custom Atomspace builder_Local
   hosts: Custom_Atomspace_builder_Local
   tags: Custom_Atomspace_builder_Local
@@ -15,7 +8,7 @@
   roles:
     - Custom_Atomspace_builder
   
-  ## deploy_annotation.yml
+  # deploy_annotation
 - name: Deploy Annotation Service
   hosts: annotation_Local
   tags: annotation_Local
@@ -31,9 +24,17 @@
   roles:
     - MORK
 
+# deploy_UI
+- name: Deploy UI Service
+  hosts: UI_Local
+  tags: UI_Local
+  become: true
+  roles:
+    - UI
+
 #Remote_Deployment
 
-## deploy_UI.yml
+# deploy_UI
 - name: Deploy UI Service
   hosts: UI_Remote
   tags: UI_Remote

--- a/playbooks/roles/Annotation/templates/.env
+++ b/playbooks/roles/Annotation/templates/.env
@@ -29,7 +29,7 @@ CADDY_PORT_FORWARD=6100
 DOCKER_HUB_REPO=dawitmelka/annotation
 
 # Redis Local Setup
-REDIS_URL=redis://localhost:6379
+REDIS_URL=redis://annotation_redis_1:6379
 REDIS_EXPIRATION=3600
 
 # Data Volume Path

--- a/playbooks/roles/Custom_Atomspace_builder/tasks/main.yml
+++ b/playbooks/roles/Custom_Atomspace_builder/tasks/main.yml
@@ -151,6 +151,48 @@
   become: no
   environment:
     HOME: "{{ install_dir }}"
+  ignore_errors: yes
+
+# Start HugeGraph container if it exists but not running
+- name: Start HugeGraph container if it exists but not running
+  docker_container:
+    name: hugegraph-atomspace
+    state: started
+  when:
+    - hugegraph_service is defined
+    - hugegraph_service.exists | default(false)
+    - hugegraph_service.container.State.Running is defined
+    - not hugegraph_service.container.State.Running
+  ignore_errors: yes
+
+- name: Start AtomSpace-API container if it exists but not running
+  docker_container:
+    name: atomspace-api
+    state: started
+  when:
+    - atomspace_service is defined
+    - atomspace_service.exists | default(false)
+    - atomspace_service.container.State.Running is defined
+    - not atomspace_service.container.State.Running
+  ignore_errors: yes
+
+# Start Neo4j container if it exists but not running
+- name: Start Neo4j container if it exists but not running
+  docker_container:
+    name: neo4j-atomspace
+    state: started
+  when:
+    - neo4j_service is defined
+    - neo4j_service.exists | default(false)
+    - neo4j_service.container.State.Running is defined
+    - not neo4j_service.container.State.Running
+  ignore_errors: yes
+
+# Wait before checking container status
+- name: Wait for containers to initialize
+  ansible.builtin.wait_for:
+    timeout: 10
+  delegate_to: localhost
 
 # Check HugeGraph container status
 - name: Check HugeGraph container status
@@ -166,15 +208,11 @@
   register: atomspace_service
   ignore_errors: yes
 
-- name: Start AtomSpace-API container if it exists but not running
-  docker_container:
-    name: atomspace-api
-    state: started
-  when:
-    - atomspace_service is defined
-    - atomspace_service.exists | default(false)
-    - atomspace_service.container.State.Running is defined
-    - not atomspace_service.container.State.Running
+# Check Neo4j container status
+- name: Check Neo4j container status
+  docker_container_info:
+    name: neo4j-atomspace
+  register: neo4j_service
   ignore_errors: yes
 
 # Print final deployment status
@@ -182,10 +220,12 @@
   debug:
     msg: |
       {% if (hugegraph_service.container is defined and hugegraph_service.container.State.Status == "running") and
-            (atomspace_service.container is defined and atomspace_service.container.State.Status == "running") %}
+            (atomspace_service.container is defined and atomspace_service.container.State.Status == "running") and
+            (neo4j_service.container is defined and neo4j_service.container.State.Status == "running") %}
       ✅ All services are up and running:
         - HugeGraph (hugegraph-atomspace)
         - AtomSpace-API (atomspace-api)
+        - Neo4j (neo4j-atomspace)
       {% else %}
       ❌ Deployment incomplete: Some services are down.
         {% if hugegraph_service.container is not defined or hugegraph_service.container.State.Status != "running" %}
@@ -194,4 +234,8 @@
         {% if atomspace_service.container is not defined or atomspace_service.container.State.Status != "running" %}
         - AtomSpace-API container is DOWN. Start it with: docker-compose up -d atomspace-api
         {% endif %}
+        {% if neo4j_service.container is not defined or neo4j_service.container.State.Status != "running" %}
+        - Neo4j container is DOWN. Start it with: docker-compose up -d neo4j-atomspace
+        {% endif %}
       {% endif %}
+

--- a/playbooks/roles/UI/files/docker-ui-run.sh
+++ b/playbooks/roles/UI/files/docker-ui-run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# Stop and remove existing container if it exists
+if docker ps -a --format '{{.Names}}' | grep -Eq '^ui$'; then
+    echo "Stopping and removing existing 'ui' container..."
+    docker stop ui
+    docker rm ui
+fi
+
+# Free port 3000 if any process is using it
+if lsof -i :3000 > /dev/null; then
+    echo "Port 3000 is in use. Killing the process..."
+    sudo kill -9 $(lsof -t -i :3000)
+fi
+
+# Check if Docker image exists
+if docker images -q ui:latest > /dev/null 2>&1 && [ -n "$(docker images -q ui:latest)" ]; then
+    echo "Docker image 'ui:latest' already exists. Skipping build."
+else
+    # Build the Docker image if it does not exist
+    echo "Building Docker image 'ui:latest'..."
+    docker build -t ui:latest .
+fi
+
+# Run the container with bridge networking and port 3000
+echo "Running Docker container 'ui'..."
+docker run -d -p 3000:3000 --env-file ./.env --network="host" --name ui ui:latest

--- a/playbooks/roles/UI/tasks/main.yml
+++ b/playbooks/roles/UI/tasks/main.yml
@@ -1,4 +1,5 @@
-- name: Create UI directory
+---
+- name: Ensure UI directory exists
   ansible.builtin.file:
     path: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui"
     state: directory
@@ -6,16 +7,7 @@
     owner: "{{ ansible_user_id | default(ansible_user) }}"
     group: "{{ ansible_user_id | default(ansible_user) }}"
 
-- name: Fix ownership of annotation-ui directory 
-  become: yes
-  ansible.builtin.file:
-    path: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui"
-    state: directory
-    recurse: yes
-    owner: "{{ ansible_user_id | default(ansible_user) }}"
-    group: "{{ ansible_user_id | default(ansible_user) }}"
-
-- name: Clone UI repository 
+- name: Clone UI repository
   ansible.builtin.git:
     repo: "https://github.com/yisehak-awm/annotation-tool.git"
     dest: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui"
@@ -23,7 +15,7 @@
     force: yes
     update: yes
 
-- name: copy .env file 
+- name: Copy .env file for UI
   ansible.builtin.copy:
     src: "templates/UI.env"
     dest: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui/.env"
@@ -32,101 +24,113 @@
     group: "{{ ansible_user_id | default(ansible_user) }}"
     force: yes
 
-- name: Nuke existing node_modules
-  ansible.builtin.file:
-    path: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui/node_modules"
-    state: absent
-  ignore_errors: yes
-
-- name: Install Node.js and npm
-  ansible.builtin.apt:
-    name:
-      - nodejs
-      - npm
-    state: present
-    update_cache: yes
-
-- name: Install dependencies
-  become: yes
-  become_user: "{{ ansible_user_id | default(ansible_user) }}"
-  ansible.builtin.shell: "npm install"
-  args:
-    chdir: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui"
-
-- name: Fix ownership of node_modules
-  become: yes
-  ansible.builtin.file:
-    path: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui/node_modules"
-    state: directory
-    recurse: yes
+- name: Copy docker run script
+  ansible.builtin.copy:
+    src: "files/docker-ui-run.sh"
+    dest: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui/docker-ui-run.sh"
+    mode: '0755'
     owner: "{{ ansible_user_id | default(ansible_user) }}"
     group: "{{ ansible_user_id | default(ansible_user) }}"
+    force: yes
 
-- name: Build application
-  become: yes
-  become_user: "{{ ansible_user_id | default(ansible_user) }}"
-  ansible.builtin.shell: "npm run build"
-  args:
+- name: Ensure docker run script is executable
+  ansible.builtin.command:
+    cmd: "chmod +x /home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui/docker-ui-run.sh"
+
+- name: Run UI Docker build and container via script
+  ansible.builtin.command:
+    cmd: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui/docker-ui-run.sh"
     chdir: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui"
-    executable: /bin/bash
-  environment:
-    NODE_OPTIONS: "--openssl-legacy-provider"
 
-- name: Start UI application and capture correct URL 
-  become: yes
-  become_user: "{{ ansible_user_id | default(ansible_user) }}"
-  ansible.builtin.shell: |
-    # Start the app and capture the correct URL
-    npm start > /home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui/ui.log 2>&1 &
-    sleep 15
-    grep -E 'Server running on|Listening on|Application started|http://localhost|https://localhost' /home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui/ui.log | grep -v npmjs | tail -1 | awk '{print $NF}' > /tmp/app_url.txt
-    if [ ! -s /tmp/app_url.txt ]; then
-      ss -tulnp | grep node | awk '{print $5}' | awk -F: '{print $NF}' | head -1 > /tmp/app_url.txt
-      echo "http://localhost:$(cat /tmp/app_url.txt)" > /tmp/app_url.txt
-    fi
-  args:
-    chdir: "/home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui"
-    executable: /bin/bash
-  environment:
-    NODE_ENV: production
-
-- name: Read captured URL
-  ansible.builtin.slurp:
-    src: /tmp/app_url.txt
-  register: app_url_file
+- name: Get network interfaces information
+  ansible.builtin.shell:
+    cmd: |
+      ip -o -4 addr show scope global | awk '{print $4}' | cut -d'/' -f1
+  register: network_ips
   changed_when: false
 
-- name: Set application URL
-  ansible.builtin.set_fact:
-    app_url: "{{ app_url_file.content | b64decode | trim | default('http://localhost:3000') }}"
+- name: Filter out common internal/docker IP ranges
+  set_fact:
+    valid_ips: "{{ network_ips.stdout_lines | reject('match', '^127\\.') | reject('match', '^172\\.1[7-9]\\.') | reject('match', '^172\\.2[0-9]\\.') | reject('match', '^172\\.3[0-1]\\.') | reject('match', '^10\\.') | reject('match', '^192\\.168\\.') | reject('match', '^169\\.254\\.') | list }}"
 
-- name: Get all IPv4 addresses
-  ansible.builtin.command: "hostname -I"
-  register: ip_addresses
+- name: Get default gateway IP for the Annotation_UI
+  ansible.builtin.shell:
+    cmd: |
+      ip route get 1.1.1.1 | awk '{print $7}' | head -1
+  register: gateway_ip
+  changed_when: false
 
-- name: Verify UI is running
-  ansible.builtin.wait_for:
-    host: "{{ app_url.split('://')[1].split(':')[0] }}"
-    port: "{{ app_url.split(':')[-1] | regex_replace('/.*', '') | int }}"
-    delay: 10
-    timeout: 60
-    state: started
+- name: Create prioritized list of working URLs
+  set_fact:
+    working_urls: "{{ ['http://localhost:3000'] }}"
 
-- name: Display deployment information
-  ansible.builtin.debug:
-    msg: |
-      ✅ Annotation UI successfully deployed!!
-      Installation directory: /home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui
-      Detected Application URL: {{ app_url }}
-      Alternative Access URLs:
-      {% for ip in ip_addresses.stdout.split() %}
-      - http://{{ ip }}:{{ app_url.split(':')[-1] | regex_replace('/.*', '') }}
+- name: Add gateway IP to URLs for the Annotation_UI
+  set_fact:
+    working_urls: "{{ working_urls + ['http://' + gateway_ip.stdout + ':3000'] }}"
+  when: gateway_ip.stdout and gateway_ip.stdout not in valid_ips
+
+- name: Add other valid IPs to URLs
+  set_fact:
+    working_urls: "{{ working_urls + ['http://' + item + ':3000'] }}"
+  loop: "{{ valid_ips }}"
+  when: item != gateway_ip.stdout
+
+- name: Check if Custom Atomspace Builder container is running
+  shell: docker ps --filter "name=atomspace-api" --filter "status=running" -q
+  register: custom_atomspace_status
+  changed_when: false
+
+- name: Check if Annotation container is running
+  shell: docker ps --filter "name=annotation_annotation_service_1" --filter "status=running" -q
+  register: annotation_status
+  changed_when: false
+
+- name: Display deployment confirmation 
+  pause:
+    prompt: |
+      
+      🎊🎉🎊🎉🎊🎉🎊🎉🎊🎉🎊🎉🎊🎉🎊🎉🎊🎉🎊🎉🎊🎉🎊🎉🎊🎉
+      
+      {% if custom_atomspace_status.stdout and annotation_status.stdout %}
+          ✨ CONGRATULATIONS! ✨
+          Your Annotation UI is LIVE and ready to use! 🚀
+          All dependent services are UP and running! ✅
+      {% else %}
+          ⚠️ ATTENTION! ⚠️
+          Some required services are not running:
+          {% if not custom_atomspace_status.stdout %}- Custom Atomspace Builder 🚫{% endif %}
+          {% if not annotation_status.stdout %}- Generic Annotation 🚫{% endif %}
+          
+          Please start them before using the UI!
+      {% endif %}
+      
+      📂 Installed at: /home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui
+      
+      🎯 YOUR ANNOTATION PORTAL:
+      ================================================================
+      {% for url in working_urls %}
+      🌟 Option {{ loop.index }}: {{ url }}
       {% endfor %}
-      Log file: /home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui/ui.log
-      To view live logs: tail -f /home/{{ ansible_user_id | default(ansible_user) }}/annotation-ui/ui.log
-
-- name: Clean up temporary file
-  ansible.builtin.file:
-    path: /tmp/app_url.txt
-
-    state: absent
+      ================================================================
+      
+      🎮 HOW TO ACCESS:
+      - 🐧 WSL users? -> Use IP addresses above (not localhost!)
+      - 🖥️ Linux/Mac? -> http://localhost:3000 OR IP addresses
+      - 🌍 Remote access? -> Use IP addresses only
+      - 🛡️ Connection issues? -> Check port 3000 in firewall
+      - 📱 Mobile device? -> Any IP address works on mobile too!
+      
+      🔍 NEED TO DEBUG?
+      - 📊 Live logs: tail -f ~/annotation-ui/ui.log
+      - 🐳 Container: docker logs ui  
+      - 🔧 Status: docker ps | grep  ui:latest
+      
+      🎯 START ANNOTATING:
+      ================================================================
+      1. Open your favorite browser 🌐                         
+      2. Copy one of the URLs above 📋                         
+      3. Start your annotation project! ✨                     
+      ================================================================
+      
+      🎉 Press ENTER when you are ready to begin! 🎉
+    seconds: 5

--- a/playbooks/roles/network/files/docker/network-setup/entrypoint.sh
+++ b/playbooks/roles/network/files/docker/network-setup/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+
 # Create network if it doesn't exist
 if ! docker network inspect rejuve-services-net >/dev/null 2>&1; then
     echo "🔹 Creating Docker network: rejuve-services-net"
@@ -21,6 +22,54 @@ if docker inspect annotation_annotation_service_1 >/dev/null 2>&1; then
     docker network connect rejuve-services-net annotation_annotation_service_1 2>/dev/null || echo "ℹ️ annotation container already connected"
 else
     echo "⚠️ annotation_annotation_service_1 container not found"
+fi
+
+# Connect annotation_redis_1
+if docker inspect annotation_redis_1 >/dev/null 2>&1; then
+    echo "🔹 Connecting annotation_redis_1 to rejuve-services-net"
+    docker network connect rejuve-services-net annotation_redis_1 2>/dev/null || echo "ℹ️ annotation_redis_1 already connected"
+else
+    echo "⚠️ annotation_redis_1 container not found"
+fi
+
+# Connect annotation_caddy_1
+if docker inspect annotation_caddy_1 >/dev/null 2>&1; then
+    echo "🔹 Connecting annotation_caddy_1 to rejuve-services-net"
+    docker network connect rejuve-services-net annotation_caddy_1 2>/dev/null || echo "ℹ️ annotation_caddy_1 already connected"
+else
+    echo "⚠️ annotation_caddy_1 container not found"
+fi
+
+# Connect annotation_mongodb_1
+if docker inspect annotation_mongodb_1 >/dev/null 2>&1; then
+    echo "🔹 Connecting annotation_mongodb_1 to rejuve-services-net"
+    docker network connect rejuve-services-net annotation_mongodb_1 2>/dev/null || echo "ℹ️ annotation_mongodb_1 already connected"
+else
+    echo "⚠️ annotation_mongodb_1 container not found"
+fi
+
+# Connect hugegraph-atomspace
+if docker inspect hugegraph-atomspace >/dev/null 2>&1; then
+    echo "🔹 Connecting hugegraph-atomspace to rejuve-services-net"
+    docker network connect rejuve-services-net hugegraph-atomspace 2>/dev/null || echo "ℹ️ hugegraph-atomspace already connected"
+else
+    echo "⚠️ hugegraph-atomspace container not found"
+fi
+
+# Connect neo4j-atomspace
+if docker inspect neo4j-atomspace >/dev/null 2>&1; then
+    echo "🔹 Connecting neo4j-atomspace to rejuve-services-net"
+    docker network connect rejuve-services-net neo4j-atomspace 2>/dev/null || echo "ℹ️ neo4j-atomspace already connected"
+else
+    echo "⚠️ neo4j-atomspace container not found"
+fi
+
+# Connect mork_container
+if docker inspect mork_container >/dev/null 2>&1; then
+    echo "🔹 Connecting mork_container to rejuve-services-net"
+    docker network connect rejuve-services-net mork_container 2>/dev/null || echo "ℹ️ mork_container already connected"
+else
+    echo "⚠️ mork_container container not found"
 fi
 
 echo "✅ Network setup complete!"

--- a/playbooks/roles/network/tasks/main.yml
+++ b/playbooks/roles/network/tasks/main.yml
@@ -36,6 +36,7 @@
     name: network-setup
     tag: latest
     source: build  
+    force_source: true  
     build:
       path: "{{ playbook_dir }}/roles/network/files/docker/network-setup"
       dockerfile: "Dockerfile"  


### PR DESCRIPTION
Dockerized deployment of the Annotation UI along with scripts to implement a shared Docker network for seamless integration between the Custom AtomSpace builder and the Generic Annotation Service.

- **UI Deployment**

  - Build and run the `ui` container with Docker
  
  - Auto-stop/remove old containers
  
  - Free up port 3000 if already in use
  
  - Supports `.env` file for environment variables
  
  - Skips rebuild if `ui:latest` image already exists

- **Shared Network Setup**

  - Creates `rejuve-services-net` Docker network if not present
  
  - Connects multiple containers (AtomSpace, Annotation, Redis, Caddy, MongoDB, HugeGraph, Neo4j, MORK)
  
  - Ensures all services run in the same network for inter-service communication

  - Enables unified orchestration through a single Ansible playbook command
  
  
